### PR TITLE
Add queryExpression option to MongoDb Source

### DIFF
--- a/mongodb-app-dependencies/pom.xml
+++ b/mongodb-app-dependencies/pom.xml
@@ -1,30 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <groupId>org.springframework.cloud.stream.app</groupId>
-    <artifactId>mongodb-app-dependencies</artifactId>
-    <version>1.1.2.BUILD-SNAPSHOT</version>
-    <packaging>pom</packaging>
-    <name>mongodb-app-dependencies</name>
-    <description>Spring Cloud Stream Mongodb App Dependencies</description>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.springframework.cloud.stream.app</groupId>
+	<artifactId>mongodb-app-dependencies</artifactId>
+	<version>1.1.2.BUILD-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>mongodb-app-dependencies</name>
+	<description>Spring Cloud Stream Mongodb App Dependencies</description>
 
-    <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
-        <groupId>org.springframework.cloud</groupId>
-        <version>1.2.1.RELEASE</version>
-        <relativePath />
-    </parent>
+	<parent>
+		<artifactId>spring-cloud-dependencies-parent</artifactId>
+		<groupId>org.springframework.cloud</groupId>
+		<version>1.2.1.RELEASE</version>
+		<relativePath/>
+	</parent>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-source-mongodb</artifactId>
-                <version>1.1.2.BUILD-SNAPSHOT</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-<profiles>
+	<properties>
+		<spring-integration.version>4.3.6.RELEASE</spring-integration.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.integration</groupId>
+				<artifactId>spring-integration-bom</artifactId>
+				<version>${spring-integration.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.stream.app</groupId>
+				<artifactId>spring-cloud-starter-stream-source-mongodb</artifactId>
+				<version>1.1.2.BUILD-SNAPSHOT</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>mongodb-app-starters-build</artifactId>
 	<version>1.1.2.BUILD-SNAPSHOT</version>
@@ -28,7 +29,8 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-<profiles>
+
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-stream-source-mongodb/README.adoc
+++ b/spring-cloud-starter-stream-source-mongodb/README.adoc
@@ -13,6 +13,7 @@ The **$$mongodb$$** $$source$$ has the following options:
 //tag::configuration-properties[]
 $$mongodb.collection$$:: $$The MongoDB collection to query$$ *($$String$$, default: `$$<none>$$`)*
 $$mongodb.query$$:: $$The MongoDB query$$ *($$String$$, default: `$${ }$$`)*
+$$mongodb.query-expression$$:: $$The SpEL expression in MongoDB query DSL style$$ *($$String$$, default: `$$<none>$$`)*
 $$mongodb.split$$:: $$Whether to split the query result as individual messages.$$ *($$Boolean$$, default: `$$true$$`)*
 $$spring.data.mongodb.authentication-database$$:: $$Authentication database name.$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.data.mongodb.database$$:: $$Database name.$$ *($$String$$, default: `$$<none>$$`)*

--- a/spring-cloud-starter-stream-source-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceProperties.java
+++ b/spring-cloud-starter-stream-source-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,51 +18,70 @@ package org.springframework.cloud.stream.app.mongodb.source;
 
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.NotEmpty;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.expression.Expression;
 
 /**
  * @author Adam Zwickey
+ * @author Artem Bilan
  *
  */
 @ConfigurationProperties("mongodb")
 public class MongodbSourceProperties {
 
-    /**
-     * The MongoDB collection to query
-     */
-    private String collection;
-    /**
-     * The MongoDB query
-     */
-    private String query = "{ }";
-    /**
-     * Whether to split the query result as individual messages.
-     */
-    private boolean split = true;
+	/**
+	 * The MongoDB collection to query
+	 */
+	private String collection;
 
-    @NotEmpty(message = "Query is required")
-    public String getQuery() {
-        return query;
-    }
+	/**
+	 * The MongoDB query
+	 */
+	private String query = "{ }";
 
-    public void setQuery(String query) {
-        this.query = query;
-    }
+	/**
+	 * The SpEL expression in MongoDB query DSL style
+	 */
+	private Expression queryExpression;
 
-    public void setCollection(String collection) {
-        this.collection = collection;
-    }
+	/**
+	 * Whether to split the query result as individual messages.
+	 */
+	private boolean split = true;
 
-    @NotBlank(message = "Collection name is required")
-    public String getCollection() {
-        return collection;
-    }
+	@NotEmpty(message = "Query is required")
+	public String getQuery() {
+		return query;
+	}
 
-    public boolean isSplit() {
-        return split;
-    }
+	public void setQuery(String query) {
+		this.query = query;
+	}
 
-    public void setSplit(boolean split) {
-        this.split = split;
-    }
+	public Expression getQueryExpression() {
+		return queryExpression;
+	}
+
+	public void setQueryExpression(Expression queryExpression) {
+		this.queryExpression = queryExpression;
+	}
+
+	public void setCollection(String collection) {
+		this.collection = collection;
+	}
+
+	@NotBlank(message = "Collection name is required")
+	public String getCollection() {
+		return collection;
+	}
+
+	public boolean isSplit() {
+		return split;
+	}
+
+	public void setSplit(boolean split) {
+		this.split = split;
+	}
+
 }

--- a/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
+++ b/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
@@ -39,7 +39,7 @@ import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.messaging.Message;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -47,10 +47,10 @@ import com.mongodb.client.MongoDatabase;
 
 /**
  * @author Adam Zwickey
- * @author ARtem Bilan
+ * @author Artem Bilan
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @SpringBootTest(properties = {
 				"spring.data.mongodb.port=0",
 				"mongodb.collection=testing"

--- a/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
+++ b/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
@@ -51,9 +51,7 @@ import com.mongodb.client.MongoDatabase;
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(
-		classes = MongodbSourceApplicationTests.MongoSourceApplication.class,
-		properties = {
+@SpringBootTest(properties = {
 				"spring.data.mongodb.port=0",
 				"mongodb.collection=testing"
 		})
@@ -74,8 +72,12 @@ public abstract class MongodbSourceApplicationTests {
 		MongoDatabase database = this.mongo.getDatabase("test");
 		database.createCollection("testing");
 		MongoCollection<Document> collection = database.getCollection("testing");
-		collection.insertOne(new Document("greeting", "hello"));
-		collection.insertOne(new Document("greeting", "hola"));
+		collection.insertOne(
+				new Document("greeting", "hello")
+						.append("name", "foo"));
+		collection.insertOne(
+				new Document("greeting", "hola")
+						.append("name", "bar"));
 	}
 
 
@@ -87,7 +89,7 @@ public abstract class MongodbSourceApplicationTests {
 			Message<?> received =
 					this.messageCollector
 							.forChannel(this.source.output())
-							.poll(2, TimeUnit.SECONDS);
+							.poll(10, TimeUnit.SECONDS);
 			assertThat(received, notNullValue());
 			assertThat(received.getPayload(), instanceOf(String.class));
 		}
@@ -104,7 +106,7 @@ public abstract class MongodbSourceApplicationTests {
 			Message<?> received =
 					this.messageCollector
 							.forChannel(this.source.output())
-							.poll(2, TimeUnit.SECONDS);
+							.poll(10, TimeUnit.SECONDS);
 			assertThat(received, notNullValue());
 			assertThat((String) received.getPayload(), containsString("hola"));
 		}
@@ -121,7 +123,7 @@ public abstract class MongodbSourceApplicationTests {
 			Message<?> received =
 					this.messageCollector
 							.forChannel(this.source.output())
-							.poll(2, TimeUnit.SECONDS);
+							.poll(10, TimeUnit.SECONDS);
 			assertThat(received, nullValue());
 		}
 
@@ -137,25 +139,11 @@ public abstract class MongodbSourceApplicationTests {
 			Message<?> received =
 					this.messageCollector
 							.forChannel(this.source.output())
-							.poll(2, TimeUnit.SECONDS);
+							.poll(10, TimeUnit.SECONDS);
 			assertThat(received, notNullValue());
 			assertThat(received.getPayload(), instanceOf(List.class));
 			assertThat(received.getPayload().toString(), containsString("hola"));
 			assertThat(received.getPayload().toString(), containsString("hello"));
-		}
-
-	}
-
-	@TestPropertySource(properties = "trigger.fixedDelay=100")
-	public static class MongoTriggerTests extends MongodbSourceApplicationTests {
-
-		@Test
-		public void test() throws InterruptedException {
-			Message<?> received =
-					this.messageCollector
-							.forChannel(this.source.output())
-							.poll(1, TimeUnit.SECONDS);
-			assertThat(received, nullValue());
 		}
 
 	}
@@ -173,7 +161,7 @@ public abstract class MongodbSourceApplicationTests {
 			Message<?> received =
 					this.messageCollector
 							.forChannel(this.source.output())
-							.poll(2, TimeUnit.SECONDS);
+							.poll(10, TimeUnit.SECONDS);
 			assertThat(received, notNullValue());
 			assertThat(received.getPayload(), instanceOf(List.class));
 			assertThat(received.getPayload().toString(), containsString("hello"));

--- a/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
+++ b/spring-cloud-starter-stream-source-mongodb/src/test/java/org/springframework/cloud/stream/app/mongodb/source/MongodbSourceApplicationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,24 @@
 
 package org.springframework.cloud.stream.app.mongodb.source;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.Matchers;
-import org.junit.After;
+import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.cloud.stream.annotation.Bindings;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.messaging.Message;
@@ -39,18 +41,22 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
 
 /**
  * @author Adam Zwickey
+ * @author ARtem Bilan
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringApplicationConfiguration(classes = { MongodbSourceApplicationTests.MongoSourceApplication.class})
-@TestPropertySource(properties = {"spring.data.mongodb.port=0"})
+@SpringBootTest(
+		classes = MongodbSourceApplicationTests.MongoSourceApplication.class,
+		properties = {
+				"spring.data.mongodb.port=0",
+				"mongodb.collection=testing"
+		})
 @DirtiesContext
 public abstract class MongodbSourceApplicationTests {
 
@@ -58,7 +64,6 @@ public abstract class MongodbSourceApplicationTests {
 	private MongoClient mongo;
 
 	@Autowired
-	@Bindings(MongodbSourceConfiguration.class)
 	protected Source source;
 
 	@Autowired
@@ -66,71 +71,121 @@ public abstract class MongodbSourceApplicationTests {
 
 	@Before
 	public void setUp() {
-		DB db = mongo.getDB("test");
-		DBCollection col = db.createCollection("testing", new BasicDBObject());
-		col.save(new BasicDBObject("greeting", "hello"));
-		col.save(new BasicDBObject("greeting", "hola"));
+		MongoDatabase database = this.mongo.getDatabase("test");
+		database.createCollection("testing");
+		MongoCollection<Document> collection = database.getCollection("testing");
+		collection.insertOne(new Document("greeting", "hello"));
+		collection.insertOne(new Document("greeting", "hola"));
 	}
 
-	@After
-	public void tearDown() throws Exception {
 
-	}
-
-	@IntegrationTest(value = {"mongodb.collection=testing", "trigger.fixedDelay=1"})
+	@TestPropertySource(properties = "trigger.fixedDelay=1")
 	public static class DefaultTests extends MongodbSourceApplicationTests {
+
 		@Test
 		public void test() throws InterruptedException {
-			Message<?> received = messageCollector.forChannel(source.output()).poll(2, TimeUnit.SECONDS);
-			assertThat(received, CoreMatchers.notNullValue());
-			assertThat(received.getPayload(), Matchers.instanceOf(String.class));
+			Message<?> received =
+					this.messageCollector
+							.forChannel(this.source.output())
+							.poll(2, TimeUnit.SECONDS);
+			assertThat(received, notNullValue());
+			assertThat(received.getPayload(), instanceOf(String.class));
 		}
+
 	}
 
-	@IntegrationTest(value = {"mongodb.collection=testing",  "mongodb.query={ 'greeting': 'hola' }", "trigger.fixedDelay=1"})
+	@TestPropertySource(properties = {
+			"mongodb.query={ 'greeting': 'hola' }",
+			"trigger.fixedDelay=1" })
 	public static class ValidQueryTests extends MongodbSourceApplicationTests {
+
 		@Test
 		public void test() throws InterruptedException {
-			Message<?> received = messageCollector.forChannel(source.output()).poll(2, TimeUnit.SECONDS);
-			assertThat(received, CoreMatchers.notNullValue());
-			assertThat((String)received.getPayload(), CoreMatchers.containsString("hola"));
+			Message<?> received =
+					this.messageCollector
+							.forChannel(this.source.output())
+							.poll(2, TimeUnit.SECONDS);
+			assertThat(received, notNullValue());
+			assertThat((String) received.getPayload(), containsString("hola"));
 		}
+
 	}
 
-	@IntegrationTest(value = {"mongodb.collection=testing", "mongodb.query={ 'greeting': 'bogus' }", "trigger.fixedDelay=1"})
+	@TestPropertySource(properties = {
+			"mongodb.query={ 'greeting': 'bogus' }",
+			"trigger.fixedDelay=1" })
 	public static class InvalidQueryTests extends MongodbSourceApplicationTests {
+
 		@Test
 		public void test() throws InterruptedException {
-			Message<?> received = messageCollector.forChannel(source.output()).poll(2, TimeUnit.SECONDS);
-			assertThat(received, CoreMatchers.nullValue());
+			Message<?> received =
+					this.messageCollector
+							.forChannel(this.source.output())
+							.poll(2, TimeUnit.SECONDS);
+			assertThat(received, nullValue());
 		}
+
 	}
 
-	@IntegrationTest(value = {"mongodb.collection=testing", "trigger.fixedDelay=1", "mongodb.split=false"})
+	@TestPropertySource(properties = {
+			"trigger.fixedDelay=1",
+			"mongodb.split=false" })
 	public static class NoSplitTests extends MongodbSourceApplicationTests {
+
 		@Test
 		public void test() throws InterruptedException {
-			Message<?> received = messageCollector.forChannel(source.output()).poll(2, TimeUnit.SECONDS);
-			assertThat(received, CoreMatchers.notNullValue());
-			assertThat(received.getPayload(), Matchers.instanceOf(List.class));
-			assertThat(received.getPayload().toString(), CoreMatchers.containsString("hola"));
-			assertThat(received.getPayload().toString(), CoreMatchers.containsString("hello"));
+			Message<?> received =
+					this.messageCollector
+							.forChannel(this.source.output())
+							.poll(2, TimeUnit.SECONDS);
+			assertThat(received, notNullValue());
+			assertThat(received.getPayload(), instanceOf(List.class));
+			assertThat(received.getPayload().toString(), containsString("hola"));
+			assertThat(received.getPayload().toString(), containsString("hello"));
 		}
+
 	}
 
-	@IntegrationTest(value = {"mongodb.collection=testing", "trigger.fixedDelay=100"})
+	@TestPropertySource(properties = "trigger.fixedDelay=100")
 	public static class MongoTriggerTests extends MongodbSourceApplicationTests {
+
 		@Test
 		public void test() throws InterruptedException {
-			Message<?> received = messageCollector.forChannel(source.output()).poll(1, TimeUnit.SECONDS);
-			assertThat(received, CoreMatchers.nullValue());
+			Message<?> received =
+					this.messageCollector
+							.forChannel(this.source.output())
+							.poll(1, TimeUnit.SECONDS);
+			assertThat(received, nullValue());
 		}
+
 	}
+
+	@TestPropertySource(properties = {
+			"mongodb.query-expression=new BasicQuery('{ }')" +
+					".limit(1)" +
+					".with(new org.springframework.data.domain.Sort('greeting'))",
+			"trigger.fixedDelay=1",
+			"mongodb.split=false" })
+	public static class QueryDslTests extends MongodbSourceApplicationTests {
+
+		@Test
+		public void test() throws InterruptedException {
+			Message<?> received =
+					this.messageCollector
+							.forChannel(this.source.output())
+							.poll(2, TimeUnit.SECONDS);
+			assertThat(received, notNullValue());
+			assertThat(received.getPayload(), instanceOf(List.class));
+			assertThat(received.getPayload().toString(), containsString("hello"));
+			assertThat(received.getPayload().toString(), not(containsString("hola")));
+		}
+
+	}
+
 
 	@SpringBootApplication
 	public static class MongoSourceApplication {
 
 	}
-
 
 }


### PR DESCRIPTION
Starting with `SI-4.3.6` we can configure query expression in the MongoDb query DSL style.

* Upgrade to `SI-4.3.6`
* Add `MongodbSourceProperties#queryExpression` property, which has a priority over just `query` if configured
* Add test to demonstrate how MongoDb query DSL can be used via a new `queryExpression` property
* Mention a new property in the `README.adoc`
* Resolve deprecations in the tests according Spring Boot upgrade