### PR TITLE
GH-6: Handle byte[] in MongoDB Sink

### DIFF
--- a/spring-cloud-starter-stream-sink-mongodb/README.adoc
+++ b/spring-cloud-starter-stream-sink-mongodb/README.adoc
@@ -2,9 +2,7 @@
 = MongoDB Sink
 
 This sink application ingest incoming data into MongoDB.
-This application is fully based on the `MongoDataAutoConfiguration`, so refer to the
-http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-mongodb[Spring Boot MongoDB Support]
-for more information.
+This application is fully based on the `MongoDataAutoConfiguration`, so refer to the http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-mongodb[Spring Boot MongoDB Support] for more information.
 
 == Input
 
@@ -12,7 +10,9 @@ for more information.
 
 === Payload
 
-* `Any POJO`
+* Any POJO
+* `String`
+* `byte[]`
 
 == Output
 

--- a/spring-cloud-starter-stream-sink-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/sink/MongodbSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/sink/MongodbSinkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,14 +19,21 @@ package org.springframework.cloud.stream.app.mongodb.sink;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.config.BindingProperties;
 import org.springframework.cloud.stream.messaging.Sink;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.config.GlobalChannelInterceptor;
 import org.springframework.integration.mongodb.outbound.MongoDbStoringMessageHandler;
+import org.springframework.integration.support.MutableMessage;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.ChannelInterceptor;
 
 /**
  * A starter configuration for MongoDB Sink applications.
@@ -56,6 +63,31 @@ public class MongodbSinkConfiguration {
 		}
 		mongoDbMessageHandler.setCollectionNameExpression(collectionExpression);
 		return mongoDbMessageHandler;
+	}
+
+
+	@Bean
+	@GlobalChannelInterceptor(patterns = Sink.INPUT)
+	public ChannelInterceptor bytesToStringChannelInterceptor() {
+		return new ChannelInterceptor() {
+
+			@Override
+			public Message<?> preSend(Message<?> message, MessageChannel channel) {
+				if (message.getPayload() instanceof byte[]) {
+					String contentType = message.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE)
+							? message.getHeaders().get(MessageHeaders.CONTENT_TYPE).toString()
+							: BindingProperties.DEFAULT_CONTENT_TYPE.toString();
+					if (contentType.contains("text") ||
+							contentType.contains("json") ||
+							contentType.contains("x-spring-tuple")) {
+
+						return new MutableMessage<>(new String(((byte[]) message.getPayload())), message.getHeaders());
+					}
+				}
+				return message;
+
+			}
+		};
 	}
 
 }

--- a/spring-cloud-starter-stream-sink-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/sink/MongodbSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-mongodb/src/main/java/org/springframework/cloud/stream/app/mongodb/sink/MongodbSinkConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.app.mongodb.sink;
 
+import java.nio.charset.StandardCharsets;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.stream.annotation.EnableBinding;
@@ -81,7 +83,9 @@ public class MongodbSinkConfiguration {
 							contentType.contains("json") ||
 							contentType.contains("x-spring-tuple")) {
 
-						return new MutableMessage<>(new String(((byte[]) message.getPayload())), message.getHeaders());
+						return new MutableMessage<>(
+								new String((byte[]) message.getPayload(), StandardCharsets.UTF_8),
+								message.getHeaders());
 					}
 				}
 				return message;


### PR DESCRIPTION
Fixes spring-cloud-stream-app-starters/mongodb#6

Currently the MongoDB Sink is useless in the Data Flow since the input
for the sink is always `byte[]` and there is no way for SCSt to determine
the target type for conversion, therefore these `byte[]` is propagated
directly to the `MongoDbStoringMessageHandler` and further to the
Spring Data MongoDB.
The last one doesn't handle `byte[]`.

* Add a `ChannelInterceptor` to convert `byte[]` to the `String` in the
`preSend()` when content-type is JSON, text or `x-spring-tuple`

**Cherry-pick to Darwin.x**