### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-sink-mongodb/README.adoc
+++ b/spring-cloud-starter-stream-sink-mongodb/README.adoc
@@ -3,7 +3,7 @@
 
 This sink application ingest incoming data into MongoDB.
 This application is fully based on the `MongoDataAutoConfiguration`, so refer to the
-http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-mongodb[Spring Boot MongoDB Support]
+https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-mongodb[Spring Boot MongoDB Support]
 for more information.
 
 == Input
@@ -36,7 +36,7 @@ $$spring.data.mongodb.uri$$:: $$Mongo database URI. When set, host and port are 
 $$spring.data.mongodb.username$$:: $$Login user of the mongo server.$$ *($$String$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
-Also see the http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[Spring Boot Documentation] for additional `MongoProperties` properties.
+Also see the https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[Spring Boot Documentation] for additional `MongoProperties` properties.
 
 == Build
 

--- a/spring-cloud-starter-stream-source-mongodb/README.adoc
+++ b/spring-cloud-starter-stream-source-mongodb/README.adoc
@@ -3,7 +3,7 @@
 
 This source polls data from MongoDB.
 This source is fully based on the `MongoDataAutoConfiguration`, so refer to the
-http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-mongodb[Spring Boot MongoDB Support]
+https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-mongodb[Spring Boot MongoDB Support]
 for more information.
 
 == Input
@@ -46,7 +46,7 @@ $$trigger.max-messages$$:: $$Maximum messages per poll, -1 means infinity.$$ *($
 $$trigger.time-unit$$:: $$The TimeUnit to apply to delay values.$$ *($$TimeUnit$$, default: `$$SECONDS$$`, possible values: `NANOSECONDS`,`MICROSECONDS`,`MILLISECONDS`,`SECONDS`,`MINUTES`,`HOURS`,`DAYS`)*
 //end::configuration-properties[]
 
-Also see the http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[Spring Boot Documentation] for additional `MongoProperties` properties.
+Also see the https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html[Spring Boot Documentation] for additional `MongoProperties` properties.
 See and `TriggerProperties` for polling options.
 
 == Build


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html ([https](https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).